### PR TITLE
Make the default (translated) error configurable both globally and on each instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,29 @@ class Person < ActiveRecord::Base
 end
 ```
 
+### Specifying a Custom, Translated Error
+
+In i18n config:
+
+``` yaml
+en-US:
+  errors:
+    messages:
+      email: must be a valid email address
+```
+
+In ruby:
+``` ruby
+# This should probably be in an initializer
+ActiveModel::Validations::EmailValidator.default_error = :email
+
+class Person
+  include ActiveModel::Validations
+  validates :email, presence: true, email: true
+  attr_accessor :email
+end
+```
+
 ### Built-in RSpec Matcher
 
 The custom matcher will be loaded automatically if RSpec is loaded

--- a/lib/active_model/validations/email_validator.rb
+++ b/lib/active_model/validations/email_validator.rb
@@ -6,6 +6,16 @@ module ActiveModel
     class EmailValidator < EachValidator
       attr_reader :record, :attribute, :value, :email, :tree
 
+      DEFAULT_ERROR = :invalid
+
+      attr_accessor :default_error
+
+      class << self
+        @default_error = DEFAULT_ERROR
+        attr_accessor :default_error
+      end
+
+
       def validate_each(record, attribute, value)
         @record, @attribute, @value = record, attribute, value
 
@@ -15,6 +25,10 @@ module ActiveModel
         add_error unless valid?
       rescue Mail::Field::ParseError
         add_error
+      end
+
+      def default_error
+        @default_error || self.class.default_error
       end
 
       private
@@ -35,7 +49,7 @@ module ActiveModel
         if message = options[:message]
           record.errors[attribute] << message
         else
-          record.errors.add(attribute, :invalid)
+          record.errors.add(attribute, default_error)
         end
       end
     end

--- a/spec/active_model/validations/email_validator_spec.rb
+++ b/spec/active_model/validations/email_validator_spec.rb
@@ -72,5 +72,31 @@ describe ActiveModel::Validations::EmailValidator do
         person.errors.to_a.should == ['Email is kinda odd looking']
       end
     end
+
+    context 'with a custom default error' do
+      context 'defined globally' do
+        before do
+          # This leaks across tests, so do it explicitly in a before/after
+          ActiveModel::Validations::EmailValidator.default_error = :exclusion
+        end
+
+        it 'translates the specified error' do
+          validator.validate(person)
+          person.errors.to_a.should == ['Email is reserved']
+        end
+
+        after do
+          ActiveModel::Validations::EmailValidator.default_error = ActiveModel::Validations::EmailValidator::DEFAULT_ERROR
+        end
+      end
+
+      context 'defined on the instance' do
+        it 'translates the specified error' do
+          validator.default_error = :accepted
+          validator.validate(person)
+          person.errors.to_a.should == ['Email must be accepted']
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
We wanted to be able to specify the default error type as something other than :invalid, rather than overriding it on every usage.

Hopefully this is useful to folks other than us!
