### PR TITLE
Only load RSpec custom matchers if they are in use.

### DIFF
--- a/lib/validate_as_email.rb
+++ b/lib/validate_as_email.rb
@@ -2,6 +2,6 @@ require 'validate_as_email/version'
 require 'active_model'
 require 'active_model/validations/email_validator'
 
-if defined?(RSpec)
+if defined?(RSpec::Matchers)
   require 'validate_as_email/rspec'
 end


### PR DESCRIPTION
A user may have overridden the default RSpec matchers in favor of another library (Mocha, RR, etc.)

We are currently (lamentably) using RR in our application and the gem breaks because RSpec::Matchers is not defined. Checking it on the outside fixes this problem.

I also created a quick test application with the default RSpec matchers still intact to make sure this change does not break the default behavior.
