### PR TITLE
Fix undefined method `tree' after commit in mail gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.ruby-gemset
+.ruby-version

--- a/lib/active_model/validations/email_validator.rb
+++ b/lib/active_model/validations/email_validator.rb
@@ -4,13 +4,13 @@ require 'mail'
 module ActiveModel
   module Validations
     class EmailValidator < EachValidator
-      attr_reader :record, :attribute, :value, :email, :tree
+      attr_reader :record, :attribute, :value, :email, :parse
 
       def validate_each(record, attribute, value)
         @record, @attribute, @value = record, attribute, value
 
         @email = Mail::Address.new(value)
-        @tree  = email.__send__(:tree)
+        @parse  = email.__send__(:parse, email.address)
 
         add_error unless valid?
       rescue Mail::Field::ParseError
@@ -20,7 +20,8 @@ module ActiveModel
       private
 
       def valid?
-        !!(domain_and_address_present? && domain_has_more_than_one_atom?)
+        !!(domain_and_address_present? &&
+           domain_has_more_than_one_atom?)
       end
 
       def domain_and_address_present?
@@ -28,7 +29,7 @@ module ActiveModel
       end
 
       def domain_has_more_than_one_atom?
-        tree.domain.dot_atom_text.elements.length > 1
+        parse.domain.split('.').length > 1
       end
 
       def add_error

--- a/lib/active_model/validations/email_validator.rb
+++ b/lib/active_model/validations/email_validator.rb
@@ -21,7 +21,8 @@ module ActiveModel
 
       def valid?
         !!(domain_and_address_present? &&
-           domain_has_more_than_one_atom?)
+           domain_has_more_than_one_atom? &&
+           local_plus_domain_equals_to_value?)
       end
 
       def domain_and_address_present?
@@ -30,6 +31,10 @@ module ActiveModel
 
       def domain_has_more_than_one_atom?
         parse.domain.split('.').length > 1
+      end
+
+      def local_plus_domain_equals_to_value?
+        parse.local + "@" + parse.domain == value
       end
 
       def add_error

--- a/spec/active_model/validations/email_validator_spec.rb
+++ b/spec/active_model/validations/email_validator_spec.rb
@@ -21,7 +21,7 @@ describe ActiveModel::Validations::EmailValidator do
 
       it 'does not add errors' do
         validator.validate(person)
-        person.errors.to_a.should == []
+        expect(person.errors.to_a).to be_empty
       end
     end
 
@@ -36,7 +36,7 @@ describe ActiveModel::Validations::EmailValidator do
 
       it 'skips adding errors is email is nil' do
         validator.validate(person)
-        person.errors.to_a.should == []
+        expect(person.errors.to_a).to be_empty
       end
     end
 
@@ -51,14 +51,14 @@ describe ActiveModel::Validations::EmailValidator do
 
       it 'skips adding errors is email is nil' do
         validator.validate(person)
-        person.errors.to_a.should == []
+        expect(person.errors.to_a).to be_empty
       end
     end
 
     context 'with no message provided' do
       it 'adds a symbol to errors for I18n lookup' do
         validator.validate(person)
-        person.errors.to_a.should == ['Email is invalid']
+        expect(person.errors.to_a).to match_array ['Email is invalid']
       end
     end
 
@@ -69,7 +69,7 @@ describe ActiveModel::Validations::EmailValidator do
 
       it 'uses the message you specify' do
         validator.validate(person)
-        person.errors.to_a.should == ['Email is kinda odd looking']
+        expect(person.errors.to_a).to match_array ['Email is kinda odd looking']
       end
     end
 
@@ -77,7 +77,7 @@ describe ActiveModel::Validations::EmailValidator do
       it 'adds invalid message error' do
         described_class.any_instance.stub(:valid?).and_raise(Mail::Field::ParseError.new(Mail::AddressList, "", nil))
         validator.validate(person)
-        expect(person.errors.to_a).to  match_array ['Email is invalid']
+        expect(person.errors.to_a).to match_array ['Email is invalid']
       end
     end
   end

--- a/spec/active_model/validations/email_validator_spec.rb
+++ b/spec/active_model/validations/email_validator_spec.rb
@@ -72,5 +72,13 @@ describe ActiveModel::Validations::EmailValidator do
         person.errors.to_a.should == ['Email is kinda odd looking']
       end
     end
+
+    context 'when raising Mail::Field::ParseError' do
+      it 'adds invalid message error' do
+        described_class.any_instance.stub(:valid?).and_raise(Mail::Field::ParseError.new(Mail::AddressList, "", nil))
+        validator.validate(person)
+        expect(person.errors.to_a).to  match_array ['Email is invalid']
+      end
+    end
   end
 end

--- a/spec/support/model.rb
+++ b/spec/support/model.rb
@@ -11,10 +11,6 @@ class Model
     @attributes[key]
   end
 
-  def email
-    @attributes[:email]
-  end
-
   def email=(email)
     @attributes[:email] = email
   end


### PR DESCRIPTION
Since the `2da7c7985c221272f6451b27ab8b41e84e0a6804` commit in `mikel/mail`, this gem has stopped working raising an `Exception`:

```
Failure/Error: validator.validate(person)
     NoMethodError:
       undefined method `tree' for #<Mail::Address:70199044312560 Address: |james@logi.cl| >
```

So I changed the `:tree` to use `:parse` method, this way I'm still able to get the `local`, `domain` and validate the email.
