### PR TITLE
Enable caching of gems during CI

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,1 @@
+bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3

--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,11 @@
 dependencies:
   override:
-    - 'rvm-exec 1.9.3-p551 bundle install'
-    - 'rvm-exec 2.0.0-p645 bundle install'
-    - 'rvm-exec 2.1.5 bundle install'
-    - 'rvm-exec 2.2.0 bundle install'
-    - 'rvm-exec jruby-9.0.4.0 bundle install'
-    - 'rvm-exec rbx-2.5.2 bundle install'
+    - 'rvm-exec 1.9.3-p551 ./ci.sh'
+    - 'rvm-exec 2.0.0-p645 ./ci.sh'
+    - 'rvm-exec 2.1.5 ./ci.sh'
+    - 'rvm-exec 2.2.0 ./ci.sh'
+    - 'rvm-exec jruby-9.0.4.0 ./ci.sh'
+    - 'rvm-exec rbx-2.5.2 ./ci.sh'
 
 test:
   override:


### PR DESCRIPTION
I'm not sure if this will work given that we're installing gems with different Ruby versions.